### PR TITLE
Update test-snan-can-build.properties.json

### DIFF
--- a/workflow-templates/test-snan-can-build.properties.json
+++ b/workflow-templates/test-snan-can-build.properties.json
@@ -1,11 +1,5 @@
 {
     "name": "Test Snap can build Workflow",
     "description": "Snapcrafters Workflow template to ensure snaps can be built.",
-    "iconName": "snapcraft",
-    "filePatterns": [
-        "snapcraft.yaml$",
-        ".snapcraft.yaml$",
-        "snap/snapcraft.yaml$",
-        "build-aux/snapcraft.yaml$"
-    ]
+    "iconName": "snapcraft"
 }


### PR DESCRIPTION
Let's try dropping the `filePatterns` altogether.. It seems the files in that list __must__ be in the root directory with no path separators (i.e. slashes)