### PR TITLE
Add processes

### DIFF
--- a/docs/PROCESSES.md
+++ b/docs/PROCESSES.md
@@ -1,0 +1,102 @@
+# Snapcrafters processes and responsibilities
+
+## Table of Contents
+
+* [Member Types](#member-types)
+* [Processes](#processes)
+  * [How to become a Snapcrafter](#join-us)
+  * [Creating a new snap](#new-snap)
+  * [Transfering a snap to upstream](#transfer-to-upstream)
+  * [How to contribute to a snap](#contributing)
+  * [How to test a snap](#testing)
+
+## Member types<a name="member-types"/>
+
+### Core members
+
+* Are "drivers" of one or more specific Snapcrafters snaps. This means they lead the effort to maintain those snaps. They triage issues, fix bugs, and rebuild the snap when there are security updates. See the Snapcrafters snaps tracker for a list of who drives what snap.
+* Create and review pull requests to the snaps. To minimize potential mistakes and improve the overall quality of our snaps, we mandate a PR and one review for any change, even if it comes from a "driver".
+* Help build and define the Snapcrafters processes.
+* Meet on a periodic basis with other Snapcrafters to discuss the processes.
+* Vet the inclusion of new members to the pool of core members.
+* Responsible for following the Snapcrafters processes and guidelines.
+* Participate in the monthly Snapcrafters group meeting * either in person or asynchronously on the forum.
+* Participate in the approval of new Snapcrafters. Even if that's just an acknowledgment.
+
+### Administrators
+
+* Administrators are core members who have full access to the GitHub organization and the Snapcrafters publisher in the store.
+* Give new core members the required privileges.
+* Help in transferring snaps to their upstream developers.
+
+### Regular members
+
+* Contribute pull requests.
+* Report issues and bugs.
+* Run tests for new builds or revisions.
+* Help automate processes.
+
+Anyone can be a regular member and contribute to our snaps in this way. We only make the distinction so you, the contributor, can see some of the things you could do to help.
+
+## Snapcrafters expectations
+
+* You will have access to the snap repo for a project that is likely not your own. You have a duty of care to ensure that any pushes to stable are tested.
+* The Snapcrafters quorum during the monthly meeting can arrange to change the process, elect new Snapcrafters, or remove Snapcrafters.
+* Before stepping away from Snapcrafters, make your intentions clear so your snaps can be re-homed.
+
+## Processes
+
+### How to become a Snapcrafter<a name="join-us"/>
+
+To become a core member of Snapcrafters you must be:
+
+* A member of the [Snapcraft forum](https://forum.snapcraft.io/) for at least six months, and in good standing.
+* An active participant in the forum.
+* An active maintainer of at least one snap in your own name.
+* Sponsored by an admin or an existing Snapcrafters core member.
+
+If you fit these criteria or have a strong argument why you should be considered anyway then add a comment on the Snapcrafters reboot post](https://forum.snapcraft.io/t/snapcrafters-reboot/24625) to tell us, and the rest of the community, about your snaps. Also tell us the Snapcrafters snaps that you would like to take on. Ideally you have familiarity with the snaps you request. State the different ways of contribution and participation you’d like to be involved in. After your have been approved, we will be in touch to discuss administrative access and co-ordinate your first Snapcrafters meeting.
+
+### Creating a new snap<a name="new-snap"/>
+
+Since our resources are limited, it’s important to see whether it actually makes sense to create a snap for an application.
+
+* Does the application benefit from being in a snap? Snaps are good for fast-moving and hard-to-install applications which are not available in regular distro repositories. Widely available and slow-moving software such as the GNU tools are often not the best candidates to put in a snap.
+* Does this application already have a snap? Adopting an existing Snap is always preferred over creating a new one. Try to contact the snap publisher and work with them to either improve their snap or take over maintenance.
+
+If it makes sense to snap the app, start from our [template repository](https://github.com/snapcrafters/fork-and-rename-me) and follow the process described in its README. Update the following settings in the repository you created:
+
+* **Manage Access:** Give the `@reviewers` team `maintain` access to the repository.
+* **Branches:** Create a branch protection rule with the pattern `*` which requires 1 approving review before merging. Check "include administrators".
+* **Options:** Disable Wikis, Sponsorships, Projects, and Discussions (unless you’re using one of them).
+
+### Transfering a snap to upstream<a name="transfer-to-upstream"/>
+
+Having the upstream developer maintain the snap of their own software is always preferred. If the upstream developer wants to take over maintenance of a snap, follow this process.
+
+1. Verify you are indeed talking to the upstream developer.
+1. Ask the developer to create a [Snap Store Brand account](https://snapcraft.io/docs/store-brand-accounts) in the name of the project, if they don’t have one yet.
+1. Add the email address of the brand account as a “collaborator” to the snap on https://dashboard.snapcraft.io. A Snapcraft administrator can help with this.
+1. Ask the store team [on the forum](https://forum.snapcraft.io) to transfer the snap to the brand account.
+1. Ask a Snapcrafter administrator to transfer the snap’s repository or to archive the repository if upstream has their own.
+
+After this process is finished, the snap is not part of Snapcrafters anymore and will not follow these processes anymore. However, even after the transition, we can still assist the developer with any issues they have maintaining the snap.
+
+### Contributing workflow<a name="contributing"/>
+
+Both external contributors _and maintainers_ use this workflow to update the snap.
+
+1. Create a personal fork of the repository.
+1. Update the code and push to your personal fork.
+1. Create a PR and ask for a review from `@reviewers`. Feel free to ping people personally too. You need at least one positive review from a core member.
+1. When the code is merged, the automatic build will push a release to the `edge` channel.
+1. Create a “call for testing” on the forum and ask people to test the `edge` channel.
+1. If those tests are successful, publish the release to the `stable` channel.
+
+### Snap testing guidelines<a name="testing"/>
+
+Testing is the next step beyond rebooting snapcrafters. Putting in place a structured process to build, test, and automate the maintenance of snaps. In the beginning snapcrafters should follow the guide to ‘good enough’ testing. In the future Igor will lead the collaboration with the Desktop and Certifications teams to properly formalise a process that snapcrafters can easily use.
+
+#### Good enough’ snap testing
+
+It is more important to test quickly and often than to test thoroughly. We don’t want to slow down our work too much, but we also want to make sure applications still work.

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,20 +1,6 @@
 ## Hi there 👋
 
-<!--
-
-**Here are some ideas to get you started:**
-
-🙋‍♀️ A short introduction - what is your organization all about?
-🌈 Contribution guidelines - how can the community get involved?
-👩‍💻 Useful resources - where can the community find your docs? Is there anything else the community should know?
-🍿 Fun facts - what does your team eat for breakfast?
-🧙 Remember, you can do mighty things with the power of [Markdown](https://guides.github.com/features/mastering-markdown/)
--->
-
-You've found the Snapcrafters. We are a group of Snap Package enthusiasts and stake-holders working together to bring apps and services to the Snap Store for Linux.
-
-## What is 'Snapcrafters'?
-The "Snapcrafters" publisher in the Snap Store is a community of people who maintain snaps of applications that are not their own. Our goal is to be a trusted and reliable source for high-quality snaps.
+We are a community of people who maintain snaps of applications that are not our own. Our goal is to be a trusted and reliable source for high-quality snaps. All snaps from the "Snapcrafters" publisher in the Snap Store are maintained by us. We also help create tooling and documentation to help others create better snap packages.
 
 - Similar to traditional distributions, we use formal processes to maintain snaps so that updates are tested and high-quality before they reach users.
 - We share maintenance workload over multiple people so there isn't a single point of failure.
@@ -25,54 +11,13 @@ The "Snapcrafters" publisher in the Snap Store is a community of people who main
 Having the upstream application developer maintain and publish a snap for their application is preferred but not always possible. If the developers are not yet interested in maintaining the snap, we fill the gap.
 
 ## Who is part of it?
+
 Our formal community is split into three groups:
-- "Regular members" contribute to the snaps.
-- "Core members" are the leaders of the group and drive development and maintenance of the snaps.
-- "Administrators" are core members with full access to the account in the Snap Store and the GitHub repositories.
 
-**Core members**
-- Are "drivers" of one or more specific Snapcrafters snaps. This means they lead the effort to maintain those snaps. They triage issues, fix bugs, and rebuild the snap when there are security updates. See the Snapcrafters snaps tracker for a list of who drives what snap.
-- Create and review pull requests to the snaps. To minimize potential mistakes and improve the overall quality of our snaps, we mandate a PR and one review for any change, even if it comes from a "driver".
-- Help build and define the Snapcrafters processes.
-- Meet on a periodic basis with other Snapcrafters to discuss the processes.
-- Vet the inclusion of new members to the pool of core members.
+- **"Regular members"** contribute to the snaps and are part of our Telegram channel.
+- **"Core members"** develop and maintain the snaps and lead this group. All core members are listed in the ["Reviewers" team](https://github.com/orgs/snapcrafters/teams/reviewers) of this organization.
+- **"Administrators"** manage this GitHub organization and the "Snapcrafters" account in the Snap Store.
 
-**Administrators**
-- Administrators are core members who have full access to the GitHub organization and the Snapcrafters publisher in the store.
-- Give new core members the required privileges.
-- Help in transferring snaps to their upstream developers.
+## How to contribute
 
-**Regular members**
-- Contribute pull requests.
-- Report issues and bugs.
-- Run tests for new builds or revisions.
-- Help automate processes.
-
-Anyone can be a regular member and contribute to our snaps in this way. We only make the distinction so you, the contributor, can see some of the things you could do to help.
-
-### Core member responsibilities
-- Responsible for following the Snapcrafters processes and guidelines.
-- Participate in the monthly Snapcrafters group meeting - either in person or asynchronously on the forum.
-- Participate in the approval of new Snapcrafters. Even if that's just an acknowledgment.
-
-### Snapcrafters expectations and rules
-- You will have access to the snap repo for a project that is likely not your own. You have a duty of care to ensure that any pushes to stable are tested.
-- The Snapcrafters quorum during the monthly meeting can arrange to change the process, elect new Snapcrafters, or remove Snapcrafters.
-- Before stepping away from Snapcrafters, make your intentions clear so your snaps can be re-homed.
-
-### How to become a Snapcrafter
-To become a core member of Snapcrafters you must be:
-
-- A member of the [Snapcraft forum](https://forum.snapcraft.io/) for at least six months, and in good standing.
-- An active participant in the forum.
-- An active maintainer of at least one snap in your own name.
-- Sponsored by an admin or an existing Snapcrafters core member.
-
-If you fit these criteria or have a strong argument why you should be considered anyway then create a new topic on the forum and tell us, and the rest of the community, about your snaps. Also tell us the Snapcrafters snaps that you would like to take on. Ideally you have familiarity with the snaps you request. State the different ways of contribution and participation you’d like to be involved in.
-After your have been approved, we will be in touch to discuss administrative access and co-ordinate your first Snapcrafters meeting.
-
-## Core Members
-
-The core members of the Snapcrafters, who help to oversee the project, are members of [this
-group](https://github.com/orgs/snapcrafters/teams/reviewers).
-
+Anyone can contribute to our snaps and toolkits. Just create a PR and tag `@reviewers` to ask us to review your contribution.


### PR DESCRIPTION
This PR attempts to add all information from our "snapcrafters publisher page, guide and docs" doc to this repo.

* I added `docs/PROCESSES.md` to contain a formal description of member types and processes
* I moved some of the more formal content from `profile/README.md` to `docs/PROCESSES.md`.

This should allow us to retire the google doc.

Note: this doesn't yet contain any info on automated testing, but I wanted to get this out ASAP and modify it later.