### PR TITLE
Update processes to better reflect reality

### DIFF
--- a/docs/PROCESSES.md
+++ b/docs/PROCESSES.md
@@ -12,50 +12,38 @@
 
 ## Member types<a name="member-types"/>
 
-### Core members
+### "Regular" members
 
-* Are "drivers" of one or more specific Snapcrafters snaps. This means they lead the effort to maintain those snaps. They triage issues, fix bugs, and rebuild the snap when there are security updates. See the Snapcrafters snaps tracker for a list of who drives what snap.
-* Create and review pull requests to the snaps. To minimize potential mistakes and improve the overall quality of our snaps, we mandate a PR and one review for any change, even if it comes from a "driver".
+* Are "maintainers" of one or more specific snaps. This means they lead the effort to maintain those snaps, although any member can help. The README of a snap should explain who the maintainer is.
+* Create and review pull requests to the snaps. To minimize potential mistakes and improve the overall quality of our snaps, we mandate a PR and one review for any change, even if it comes from the maintainer.
 * Help build and define the Snapcrafters processes.
-* Meet on a periodic basis with other Snapcrafters to discuss the processes.
-* Vet the inclusion of new members to the pool of core members.
-* Responsible for following the Snapcrafters processes and guidelines.
-* Participate in the monthly Snapcrafters group meeting * either in person or asynchronously on the forum.
-* Participate in the approval of new Snapcrafters. Even if that's just an acknowledgment.
+* Vet the inclusion of new members.
+* Follow the Snapcrafters processes and guidelines.
 
 ### Administrators
 
-* Administrators are core members who have full access to the GitHub organization and the Snapcrafters publisher in the store.
-* Give new core members the required privileges.
+* Have full access to the GitHub organization and the Snapcrafters publisher in the store.
+* Give new members the required privileges.
 * Help in transferring snaps to their upstream developers.
-
-### Regular members
-
-* Contribute pull requests.
-* Report issues and bugs.
-* Run tests for new builds or revisions.
-* Help automate processes.
-
-Anyone can be a regular member and contribute to our snaps in this way. We only make the distinction so you, the contributor, can see some of the things you could do to help.
 
 ## Snapcrafters expectations
 
 * You will have access to the snap repo for a project that is likely not your own. You have a duty of care to ensure that any pushes to stable are tested.
-* The Snapcrafters quorum during the monthly meeting can arrange to change the process, elect new Snapcrafters, or remove Snapcrafters.
 * Before stepping away from Snapcrafters, make your intentions clear so your snaps can be re-homed.
 
 ## Processes
 
 ### How to become a Snapcrafter<a name="join-us"/>
 
-To become a core member of Snapcrafters you must be:
+To become a member of Snapcrafters you must be:
 
 * A member of the [Snapcraft forum](https://forum.snapcraft.io/) for at least six months, and in good standing.
 * An active participant in the forum.
 * An active maintainer of at least one snap in your own name.
-* Sponsored by an admin or an existing Snapcrafters core member.
 
-If you fit these criteria or have a strong argument why you should be considered anyway then add a comment on the [Snapcrafters reboot post](https://forum.snapcraft.io/t/snapcrafters-reboot/24625) to tell us, and the rest of the community, about your snaps. Also tell us the Snapcrafters snaps that you would like to take on. Ideally you have familiarity with the snaps you request. State the different ways of contribution and participation you’d like to be involved in. After your have been approved, we will be in touch to discuss administrative access and co-ordinate your first Snapcrafters meeting.
+If you fit these criteria then add a comment on the [Snapcrafters reboot post](https://forum.snapcraft.io/t/snapcrafters-reboot/24625) to tell us, and the rest of the community, about your snaps. Also tell us the Snapcrafters snaps that you would like to take on. Ideally you have familiarity with the snaps you request. State the different ways of contribution and participation you’d like to be involved in. After your have been approved, we will be in touch to discuss administrative access.
+
+We elect members on a "provided nobody says no" basis. If none of the snapcrafters vote against your membership, you become a member!
 
 ### Creating a new snap<a name="new-snap"/>
 
@@ -66,9 +54,11 @@ Since our resources are limited, it’s important to see whether it actually mak
 
 If it makes sense to snap the app, start from our [template repository](https://github.com/snapcrafters/fork-and-rename-me) and follow the process described in its README. Update the following settings in the repository you created:
 
-* **Manage Access:** Give the `@reviewers` team `maintain` access to the repository.
-* **Branches:** Create a branch protection rule with the pattern `*` which requires 1 approving review before merging. Check "include administrators".
+* **Manage Access:** Set up permissions as explained in [Permissions](https://github.com/snapcrafters/.github/wiki/Permissions-and-Secrets)
 * **Options:** Disable Wikis, Sponsorships, Projects, and Discussions (unless you’re using one of them).
+* **Metadata:**
+  * **Description** should be `A community-maintained package to easily install <Snap Name> on Linux`.
+  * **Website** should point to the snap in the snap store.
 
 ### Transfering a snap to upstream<a name="transfer-to-upstream"/>
 
@@ -84,19 +74,8 @@ After this process is finished, the snap is not part of Snapcrafters anymore and
 
 ### Contributing workflow<a name="contributing"/>
 
-Both external contributors _and maintainers_ use this workflow to update the snap.
-
-1. Create a personal fork of the repository.
-1. Update the code and push to your personal fork.
-1. Create a PR and ask for a review from `@reviewers`. Feel free to ping people personally too. You need at least one positive review from a core member.
-1. When the code is merged, the automatic build will push a release to the `edge` channel.
-1. Create a “call for testing” on the forum and ask people to test the `edge` channel.
-1. If those tests are successful, publish the release to the `stable` channel.
+For more information on our contribution process, see [our Contributing Guide](https://github.com/snapcrafters/.github/wiki/Contributing).
 
 ### Snap testing guidelines<a name="testing"/>
 
-Testing is the next step beyond rebooting snapcrafters. Putting in place a structured process to build, test, and automate the maintenance of snaps. In the beginning snapcrafters should follow the guide to ‘good enough’ testing. In the future Igor will lead the collaboration with the Desktop and Certifications teams to properly formalise a process that snapcrafters can easily use.
-
-#### Good enough’ snap testing
-
-It is more important to test quickly and often than to test thoroughly. We don’t want to slow down our work too much, but we also want to make sure applications still work.
+Snapcrafters should follow "good enough" testing. It is more important to test quickly and often than to test thoroughly. We don’t want to slow down our work too much, but we also want to make sure applications still work.


### PR DESCRIPTION
I also pointed to the contributing docs on the wiki.

* The wiki contains the less-formal and more-frequently-changing documentation about how to contribute etc. So it can be changed without requiring a review.
* This repo contains the more-formal processes such as how to become a Snapcrafter. This can only be changed with a review.
